### PR TITLE
Fix issue that causes some cleaned stack traces to contain a trailing )

### DIFF
--- a/lib/md/cleanStackTrace.js
+++ b/lib/md/cleanStackTrace.js
@@ -4,7 +4,7 @@ function cleanStackTrace(stack) {
   const lines = stack.split("\n");
   let numStackLines = 0;
   for (let i = 0; i < lines.length; i += 1) {
-    const matchStackLine = lines[i].match(/^( +at (?:[\w<>]+ \()?)[^)]+(\)?)$/);
+    const matchStackLine = lines[i].match(/^( +at (?:.+ \()?)[^)]+(\)?)$/);
     if (matchStackLine) {
       numStackLines += 1;
       if (numStackLines <= 2) {

--- a/test/md/cleanStackTrace.spec.js
+++ b/test/md/cleanStackTrace.spec.js
@@ -26,6 +26,16 @@ describe("cleanStackTrace", function() {
     );
   });
 
+  it("should accept special characters and spaces in the function name", function() {
+    expect(
+      cleanStackTrace(
+        "foo\n  at Object.attri bute$☺ (/home/andreas/work/css-generators/node_modules/postcss-minify-selectors/dist/index.js:46:47)"
+      ),
+      "to equal",
+      "foo\n  at Object.attri bute$☺ (/path/to/file.js:x:y)"
+    );
+  });
+
   it("should only preserve 2 stack locations per trace", function() {
     expect(
       cleanStackTrace(


### PR DESCRIPTION
Eg. at the bottom of https://github.com/papandreou/css-generators/blob/master/README.md

It happens because the regexp didn't anticipate the `.` in `at Object.attribute (/path/to/index.js:46:47)`.

Seems like that string can contain all characters, including spaces:

```js
foo = {'ba r☺'() {throw new Error('qvcwevq');}}
try {foo['ba r☺']()}catch(err){console.log(err);}
```

```
Error: qvcwevq
    at Object.ba r☺ (repl:1:25)
    at repl:1:18
    at Script.runInThisContext (vm.js:120:20)
    at REPLServer.defaultEval (repl.js:430:29)
    at bound (domain.js:426:14)
    at REPLServer.runBound [as eval] (domain.js:439:12)
    at REPLServer.onLine (repl.js:758:10)
    at REPLServer.emit (events.js:323:22)
    at REPLServer.EventEmitter.emit (domain.js:482:12)
    at REPLServer.Interface._onLine (readline.js:322:10)
```